### PR TITLE
DOC: Fix broken scipy.datasets.face link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # dataset-face
 
 This repo serves the data files for the
-[scipy.dataset.face](https://scipy.github.io/devdocs/reference/dataset/face.html)
+[scipy.datasets.face](https://scipy.github.io/devdocs/reference/generated/scipy.datasets.face.html)
 (visit for details on dataset) method in 
 the [scipy.datasets](https://scipy.github.io/devdocs/reference/datasets.html)
 submodule.
@@ -10,4 +10,4 @@ You may want to read the
 [Usage of Datasets](https://scipy.github.io/devdocs/reference/datasets.html#usage-of-datasets)
 and
 [How dataset retrieval and storage works?](https://scipy.github.io/devdocs/reference/datasets.html#how-dataset-retrieval-and-storage-works)
-to uncover the working of scipy.datasets module with pooch.
+to uncover the working of scipy.datasets submodule with pooch.


### PR DESCRIPTION
Just saw that the link to docs was broken. This should fix it, and also sent PRs for other datasets.